### PR TITLE
Fixed error by updating the Reflected method AddString

### DIFF
--- a/VChat/Patches/Chat/Chat.AddString.cs
+++ b/VChat/Patches/Chat/Chat.AddString.cs
@@ -20,10 +20,10 @@ namespace VChat.Patches
         }
     }
 
-    [HarmonyPatch(typeof(Chat), nameof(Chat.AddString), typeof(string))]
+    [HarmonyPatch(typeof(Chat), nameof(Chat.AddString), typeof(string), typeof(string), typeof(Talker.Type))]
     public static class ChatPatchAddStringToBuffer
     {
-        private static bool Prefix(ref Chat __instance, ref string text)
+        private static bool Prefix(ref Chat __instance, ref string user, ref string text, ref Talker.Type type)
         {
             // Display chat window when a new message is received.
             if (VChatPlugin.Settings.ShowChatWindowOnMessageReceived)


### PR DESCRIPTION
Solves #11 

Fixed error by updating the Reflected method AddString, by adding missing parameter data.

---

Root Issue Error Logs:

```
[Warning:  HarmonyX] AccessTools.DeclaredMethod: Could not find method for type Chat and name AddString and parameters (string)
[Error  : Unity Log] ArgumentException: Undefined target method for patch method static bool VChat.Patches.ChatPatchAddStringToBuffer::Prefix(Chat& __instance, String& text)
Stack trace:
HarmonyLib.PatchClassProcessor.PatchWithAttributes (System.Reflection.MethodBase& lastOriginal) (at <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0)
HarmonyLib.PatchClassProcessor.Patch () (at <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0)
Rethrow as HarmonyException: Patching exception in method null
HarmonyLib.PatchClassProcessor.ReportException (System.Exception exception, System.Reflection.MethodBase original) (at <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0)
HarmonyLib.PatchClassProcessor.Patch () (at <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0)
HarmonyLib.Harmony.<PatchAll>b__11_0 (System.Type type) (at <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0)
HarmonyLib.CollectionExtensions.Do[T] (System.Collections.Generic.IEnumerable`1[T] sequence, System.Action`1[T] action) (at <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0)
HarmonyLib.Harmony.PatchAll (System.Reflection.Assembly assembly) (at <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0)
HarmonyLib.Harmony.CreateAndPatchAll (System.Reflection.Assembly assembly, System.String harmonyInstanceId) (at <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0)
VChat.VChatPlugin.Awake () (at <d80a3e19e1944aadae986a71e2810762>:0)
UnityEngine.GameObject:AddComponent(Type)
BepInEx.Bootstrap.Chainloader:Start()
UnityEngine.Application:.cctor()
```